### PR TITLE
message queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,5 @@ out/
 .kotlin
 
 *.properties
-application.yaml
+*.yaml
 *.yml

--- a/src/main/kotlin/com/lab/labkotlin/common/Message.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/Message.kt
@@ -1,0 +1,30 @@
+package com.lab.labkotlin.common
+
+class Message(
+    val messageType: MessageType,
+    val content: String,
+    val messageFailHandler: MessageFailHandler
+) {
+    private var failCount = 0L
+    private var exceptionList = mutableListOf<Exception>()
+
+    fun addException(e: Exception) {
+        exceptionList.add(e)
+    }
+
+    fun increaseFailCount() {
+        failCount++
+    }
+
+    fun takeFail(e: Exception) {
+        messageFailHandler.handleFail(this, e)
+    }
+
+    fun getFailCount(): Long {
+        return failCount
+    }
+
+    fun getExceptionList(): List<Exception> {
+        return exceptionList
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/MessageConsumer.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/MessageConsumer.kt
@@ -19,8 +19,7 @@ class MessageConsumer(
     private var isTerminated = true
     private val log = LoggerFactory.getLogger(MessageConsumer::class.java)
 
-    @Scheduled(cron = "*/3 * * * * *")
-    private fun consume(){
+    fun consume(){
         log.warn("메시지 큐 내부 메시지 확인")
         for(i in 1..10) {
             messageQueue.add(messageFactory.createMessage(MessageType.NOTI, "테스트 메시지 $i"))

--- a/src/main/kotlin/com/lab/labkotlin/common/MessageConsumer.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/MessageConsumer.kt
@@ -1,0 +1,71 @@
+package com.lab.labkotlin.common
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.stream.IntStream
+
+@Component
+class MessageConsumer(
+    private val messageHandlerList: List<MessageHandler>,
+    private val messageFailHandler: MessageFailHandler,
+    private val messageQueue: MessageQueue,
+    private val messageFactory: MessageFactory
+) {
+    private val threadPoolSize = 2
+    private var isTerminated = true
+    private val log = LoggerFactory.getLogger(MessageConsumer::class.java)
+
+    @Scheduled(cron = "*/3 * * * * *")
+    private fun consume(){
+        log.warn("메시지 큐 내부 메시지 확인")
+        for(i in 1..10) {
+            messageQueue.add(messageFactory.createMessage(MessageType.NOTI, "테스트 메시지 $i"))
+        }
+        if(!messageQueue.isEmpty() && isTerminated){
+            executeThreadPool()
+        }
+    }
+
+    private fun executeThreadPool(){
+        isTerminated = false
+
+        log.warn("현재 메시지 개수 : ${messageQueue.size()}")
+        log.warn("현재 설정된 스레드 풀 크기 : $threadPoolSize")
+        log.info("현재 메시지 : ${messageQueue.queue.map { it.content }}")
+        val executor = Executors.newFixedThreadPool(threadPoolSize)
+
+        IntStream.range(0, threadPoolSize).forEach{ threadNumber ->
+            CompletableFuture.runAsync(this::process, executor)
+        }
+        executor.shutdown()
+    }
+
+    private fun process(){
+        log.info("메시지 처리 시작")
+        var message : Message
+        while (!messageQueue.isEmpty()){
+            message = messageQueue.poll()?: break
+            log.info("메시지 처리 중")
+            handleMessage(message)
+        }
+        isTerminated = true
+    }
+
+    private fun handleMessage(
+        message : Message
+    ){
+
+        messageHandlerList.forEach { messageHandler ->
+            try {
+                messageHandler.handle(message)
+            } catch (e: Exception) {
+                log.error("메시지 처리 실패")
+                messageFailHandler.handleFail(message, e)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/MessageFactory.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/MessageFactory.kt
@@ -1,0 +1,14 @@
+package com.lab.labkotlin.common
+
+import org.springframework.stereotype.Component
+
+@Component
+class MessageFactory(
+    val messageFailHandler: MessageFailHandler
+) {
+
+    fun createMessage(messageType: MessageType, message: String): Message {
+        return Message(messageType, message, messageFailHandler)
+    }
+
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/MessageFailHandler.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/MessageFailHandler.kt
@@ -1,0 +1,37 @@
+package com.lab.labkotlin.common
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class MessageFailHandler(
+    val messageQueue: MessageQueue
+) {
+    private val MAX_FAIL_COUNT = 100
+    private val log = LoggerFactory.getLogger(MessageFailHandler::class.java)
+
+    fun handleFail(message: Message, e: Exception) {
+        message.addException(e)
+        message.increaseFailCount()
+        if(message.getFailCount() > MAX_FAIL_COUNT){
+            handleTooManyFails(message)
+        }else{
+            messageQueue.add(message)
+        }
+
+    }
+
+    fun handleTooManyFails(message: Message){
+        log.warn("최대 실패 횟수 ${MAX_FAIL_COUNT}를 초과")
+        log.warn("예외 리스트")
+        val exceptionList = message.getExceptionList()
+        log.warn("실패한 메시지 : ${message}")
+        exceptionList.forEach { exception ->
+            exception.printStackTrace()
+            log.warn("-----------------------------")
+        }
+        log.warn("예외 리스트 종료")
+
+    }
+
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/MessageHandler.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/MessageHandler.kt
@@ -1,0 +1,6 @@
+package com.lab.labkotlin.common
+
+
+interface MessageHandler {
+    fun handle(message: Message)
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/MessageQueue.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/MessageQueue.kt
@@ -1,0 +1,25 @@
+package com.lab.labkotlin.common
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentLinkedQueue
+
+@Component
+class MessageQueue(
+    val queue: ConcurrentLinkedQueue<Message> = ConcurrentLinkedQueue()
+) {
+    fun add(message: Message) {
+        queue.add(message)
+    }
+
+    fun poll(): Message? {
+        return queue.poll()
+    }
+
+    fun isEmpty(): Boolean {
+        return queue.isEmpty()
+    }
+
+    fun size(): Int {
+        return queue.size
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/MessageType.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/MessageType.kt
@@ -1,0 +1,5 @@
+package com.lab.labkotlin.common
+
+enum class MessageType(s: String) {
+    NOTI("알림")
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/NotiMessageHandler.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/NotiMessageHandler.kt
@@ -1,0 +1,17 @@
+package com.lab.labkotlin.common
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class NotiMessageHandler: MessageHandler {
+    private val log = LoggerFactory.getLogger(NotiMessageHandler::class.java)
+
+    override fun handle(message: Message) {
+        if(message.messageType != MessageType.NOTI) {
+            log.warn("메시지 핸들러가 처리할 수 없는 메시지 타입입니다.")
+            return
+        }
+        log.info("${Thread.currentThread().name}가 ${message.messageType} 타입의 메시지 {${message.content}}를 처리했습니다.")
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/controller/TestController.kt
+++ b/src/main/kotlin/com/lab/labkotlin/controller/TestController.kt
@@ -1,0 +1,25 @@
+package com.lab.labkotlin.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/test")
+class TestController {
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    fun getTest(): String {
+        return "Get Test Success"
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping
+    fun postTest(): String {
+        return "Post Test Success"
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/scheduler/MessageScheduler.kt
+++ b/src/main/kotlin/com/lab/labkotlin/scheduler/MessageScheduler.kt
@@ -1,0 +1,22 @@
+package com.lab.labkotlin.scheduler
+
+import com.lab.labkotlin.common.Message
+import com.lab.labkotlin.common.MessageFactory
+import com.lab.labkotlin.common.MessageType
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class MessageScheduler(
+    private val messageFactory: MessageFactory
+) {
+    private val log = LoggerFactory.getLogger(MessageScheduler::class.java)
+
+    @Scheduled(cron = "*/5 * * * * *")
+    fun supplyMessage(): Message {
+        log.info("Supplying message...")
+        return messageFactory.createMessage(MessageType.NOTI, "Hello, World!")
+
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/scheduler/MessageScheduler.kt
+++ b/src/main/kotlin/com/lab/labkotlin/scheduler/MessageScheduler.kt
@@ -1,6 +1,7 @@
 package com.lab.labkotlin.scheduler
 
 import com.lab.labkotlin.common.Message
+import com.lab.labkotlin.common.MessageConsumer
 import com.lab.labkotlin.common.MessageFactory
 import com.lab.labkotlin.common.MessageType
 import org.slf4j.LoggerFactory
@@ -9,14 +10,14 @@ import org.springframework.stereotype.Component
 
 @Component
 class MessageScheduler(
-    private val messageFactory: MessageFactory
+    private val messageConsumer: MessageConsumer
 ) {
     private val log = LoggerFactory.getLogger(MessageScheduler::class.java)
 
-    @Scheduled(cron = "*/5 * * * * *")
-    fun supplyMessage(): Message {
-        log.info("Supplying message...")
-        return messageFactory.createMessage(MessageType.NOTI, "Hello, World!")
+    @Scheduled(cron = "*/3 * * * * *")
+    fun supplyMessage() {
+        log.info("-----------Supplying message...-------------")
+        messageConsumer.consume()
 
     }
 }


### PR DESCRIPTION
- Message
  - 메시지 타입과 content를 받음
    - 어떤 타입의 메시지인지 선택하게 함으로써 컴파일 단에서 잘 못 된 메시지가 들어오는 것을 잡을 수 있음.
    - 현재 contents는 String으로 받음
      - 이후 다양한 값을 받을 수 있게 제네릭을 사용하는 것도 좋아보임
  - failCount와 ExceptionList를 캐싱
    - 해당 메시지의 재시도 횟수와 발생한 Exception을 캐싱함
- MessageType
  - Message의 타입을 정의
    - 이를 통해 Message를 생성할 때 어떤 타입의 메시지인지 선택할 수 있음
    - 명시된 타입 사용을 통해 잘 못된 메시지 타입은 컴파일에서 잡을 수 있게 해줌
- MessageConsumer
  - 메시지를 소비함
  - 메시지 다중 처리를 위해 스레드를 여러 개 사용함
- MessageFailHandler
  - 실패한 메시지에 대해서 retry를 위해 해당 메시지의 Fail 카운트를 증가 시키고, ExceptionList에 Exception을 저장함
  - MAX_FAIL_COUNT를 넘어가는 메시지는 실패 처리함
- MessageHandler
  - 메시지 타입이 새로 추가될 수 있기에 인터페이스화함
  - 각 메시지 처리 핸들러는 메시지를 처리하는 handle 메소드를 구현해야함
- MessageScheduler
  - 3초 마다 MessageConsumer를 호출해 메시지를 소비하게 함