### PR TITLE
[Feat] Exception handler + Custom Exception

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/lab/labkotlin/common/exception/BusinessException.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/exception/BusinessException.kt
@@ -1,0 +1,15 @@
+package com.lab.labkotlin.common.exception
+
+import org.springframework.http.HttpStatus
+
+open class BusinessException(
+    errorCode: ErrorCode
+) : RuntimeException(errorCode.getMessage()) {
+    val httpStatus: HttpStatus
+    val code: String
+
+    init {
+        httpStatus = errorCode.getStatus()
+        code = errorCode.getCode()
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/exception/CustomExceptionHandler.kt
@@ -1,0 +1,22 @@
+package com.lab.labkotlin.common.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class CustomExceptionHandler {
+
+    @ExceptionHandler(BusinessException::class)
+    fun businessExceptionHandler(e: BusinessException): ResponseEntity<ErrorResponse> {
+        val errorResponse = ErrorResponse(
+            e.httpStatus,
+            e.code,
+            e.message?:""
+        )
+        return ResponseEntity.status(e.httpStatus).body(errorResponse)
+    }
+
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/exception/ErrorCode.kt
@@ -1,0 +1,9 @@
+package com.lab.labkotlin.common.exception
+
+import org.springframework.http.HttpStatus
+
+interface ErrorCode {
+    fun getStatus(): HttpStatus
+    fun getCode(): String
+    fun getMessage(): String
+}

--- a/src/main/kotlin/com/lab/labkotlin/common/exception/ErrorResponse.kt
+++ b/src/main/kotlin/com/lab/labkotlin/common/exception/ErrorResponse.kt
@@ -1,0 +1,9 @@
+package com.lab.labkotlin.common.exception
+
+import org.springframework.http.HttpStatus
+
+data class ErrorResponse(
+    val status: HttpStatus,
+    val code: String,
+    val message: String,
+)

--- a/src/main/kotlin/com/lab/labkotlin/controller/TestController.kt
+++ b/src/main/kotlin/com/lab/labkotlin/controller/TestController.kt
@@ -22,4 +22,10 @@ class TestController {
     fun postTest(): String {
         return "Post Test Success"
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{resourceId}")
+    fun getExceptionHanlderTest(): String {
+        return throw TestException.ResourceNotFound()
+    }
 }

--- a/src/main/kotlin/com/lab/labkotlin/controller/TestErrorCode.kt
+++ b/src/main/kotlin/com/lab/labkotlin/controller/TestErrorCode.kt
@@ -1,0 +1,16 @@
+package com.lab.labkotlin.controller
+
+import com.lab.labkotlin.common.exception.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class TestErrorCode(
+    private val status: HttpStatus,
+    private val code: String,
+    private val message: String,
+): ErrorCode {
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEST-001", "요청한 리소스가 존재하지 않습니다.");
+
+    override fun getStatus(): HttpStatus = status
+    override fun getCode(): String = code
+    override fun getMessage(): String = message
+}

--- a/src/main/kotlin/com/lab/labkotlin/controller/TestException.kt
+++ b/src/main/kotlin/com/lab/labkotlin/controller/TestException.kt
@@ -1,0 +1,10 @@
+package com.lab.labkotlin.controller
+
+import com.lab.labkotlin.common.exception.BusinessException
+import com.lab.labkotlin.common.exception.ErrorCode
+
+abstract class TestException(
+    errorCode: ErrorCode
+): BusinessException(errorCode) {
+    class ResourceNotFound: TestException(TestErrorCode.RESOURCE_NOT_FOUND)
+}


### PR DESCRIPTION
### 2.5.0 버전 Swagger사용시 @RestControllerAdvice를 사용하면 NoSuchMethodError가 발생
- ControllerAdviceBean의 생성자가 Spring 6.2버전부터 변경되었다고 함.
  - swagger 2.5.0은 Spring 6.1까지의 API를 기준으로 되어 있어서 오류 발생함
  - RestControllerAdvice가 포함된 클래스가 문서화 대상이 되면 ControllerAdviceBean(bean) 호출했을 때 **존재하지 않는 생성자에 접근**하기 때문에 NoSuchMethodError가 발생함
  - 2.5.0 -> spring 6.1 기준
  - 2.7.0 -> spring 6.2 기준으로 리팩토링
- 해결 방법
  - @RestControllerAdvice 와 함께 **@Hidden**을 사용해서 문서화 대상에서 숨김
    - 숨겨도 여전히 사용은 됨.
  - **swagger 버전을 올림**
    - spring 버전 변경에 따른 문제가 발생할 수 있을 것 같아서 버전을 올리기로 함.
    - 어차피 혼자 공부하는 거고, 초기라서 버전 올리는 데 부담은 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling now delivers consistent, structured error responses for improved user guidance.
  - A new endpoint has been added to demonstrate and test the improved error reporting.

- **Chores**
  - Upgraded the API documentation interface dependency to ensure better performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->