### PR TITLE
Feat : mixpanel 이벤트 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 //    testImplementation("org.springframework.batch:spring-batch-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // Mixpanel Java SDK
+    implementation("com.mixpanel:mixpanel-java:1.5.0")
 }
 
 kotlin {

--- a/src/main/kotlin/com/lab/labkotlin/application/MixpanelEventListener.kt
+++ b/src/main/kotlin/com/lab/labkotlin/application/MixpanelEventListener.kt
@@ -1,0 +1,42 @@
+package com.lab.labkotlin.application
+
+import com.lab.labkotlin.domain.MixpanelEvent
+import com.mixpanel.mixpanelapi.ClientDelivery
+import com.mixpanel.mixpanelapi.MessageBuilder
+import com.mixpanel.mixpanelapi.MixpanelAPI
+import org.json.JSONObject
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class MixpanelEventListener(
+    @Value("\${mixpanel.token}")
+    val token: String,
+) {
+    private val delivery: ClientDelivery = ClientDelivery()
+
+    private val mixpanelAPI: MixpanelAPI = MixpanelAPI()
+
+    @Async
+    @EventListener
+    fun eventTrack(mixpanelEvent: MixpanelEvent) {
+
+        // 믹스패널 이벤트 메시지 생성
+        val messageBuilder = MessageBuilder(token)
+
+        // 이벤트 생성
+        val sentEvent: JSONObject =
+            messageBuilder.event(
+                mixpanelEvent.memberId.toString(),
+                mixpanelEvent.mixpanelEventName.value,
+                JSONObject(mixpanelEvent.property),
+            )
+        println("Mixpanel Event: $sentEvent")
+        delivery.addMessage(sentEvent)
+        println("Mixpanel Delivery: $delivery")
+
+        mixpanelAPI.deliver(delivery)
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/controller/MixpanelEventController.kt
+++ b/src/main/kotlin/com/lab/labkotlin/controller/MixpanelEventController.kt
@@ -1,0 +1,38 @@
+package com.lab.labkotlin.controller
+
+import com.lab.labkotlin.controller.req.ODsayCallCountReq
+import com.lab.labkotlin.domain.MixpanelEvent
+import com.lab.labkotlin.domain.ODsayCallCountProperty
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/mixpanel")
+@RestController
+class MixpanelEventController(
+    val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    @PostMapping("/odsay-call-count")
+    fun oDsayCallCountEvent(
+        @RequestBody
+        oDsayCallCountReq: ODsayCallCountReq
+    ) {
+        println("Received ODsay Call Count Event: $oDsayCallCountReq")
+        applicationEventPublisher.publishEvent(
+            MixpanelEvent(
+                mixpanelEventName = MixpanelEvent.MixpanelEventName.ODSAY_CALL_COUNT,
+                memberId = oDsayCallCountReq.memberId,
+                property = ODsayCallCountProperty(
+                    startX = "12.12",
+                    startY = "123.123",
+                    endX = "21.21",
+                    endY = "321.321",
+                    oDsayCallCount = oDsayCallCountReq.oDsayCallCount,
+                    routeCount = oDsayCallCountReq.routeCount,
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/controller/req/ODsayCallCountReq.kt
+++ b/src/main/kotlin/com/lab/labkotlin/controller/req/ODsayCallCountReq.kt
@@ -1,0 +1,7 @@
+package com.lab.labkotlin.controller.req
+
+data class ODsayCallCountReq(
+    val memberId: Long,
+    val oDsayCallCount: Int,
+    val routeCount: Int,
+)

--- a/src/main/kotlin/com/lab/labkotlin/domain/MixpanelEvent.kt
+++ b/src/main/kotlin/com/lab/labkotlin/domain/MixpanelEvent.kt
@@ -1,0 +1,11 @@
+package com.lab.labkotlin.domain
+
+class MixpanelEvent(
+    val mixpanelEventName: MixpanelEventName,
+    val memberId: Long,
+    val property: MixpanelEventProperty,
+) {
+    enum class MixpanelEventName(val value: String) {
+        ODSAY_CALL_COUNT("odsay_call_count"),
+    }
+}

--- a/src/main/kotlin/com/lab/labkotlin/domain/MixpanelEventProperty.kt
+++ b/src/main/kotlin/com/lab/labkotlin/domain/MixpanelEventProperty.kt
@@ -1,0 +1,3 @@
+package com.lab.labkotlin.domain
+
+interface MixpanelEventProperty

--- a/src/main/kotlin/com/lab/labkotlin/domain/ODsayCallCountProperty.kt
+++ b/src/main/kotlin/com/lab/labkotlin/domain/ODsayCallCountProperty.kt
@@ -1,0 +1,10 @@
+package com.lab.labkotlin.domain
+
+class ODsayCallCountProperty (
+    var startX: String,
+    var startY: String,
+    var endX: String,
+    var endY: String,
+    var oDsayCallCount: Int,
+    var routeCount: Int,
+) : MixpanelEventProperty


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Mixpanel 연동 도입: 앱 내 ODsay 호출/경로 수를 이벤트로 비동기 수집·전송합니다.
  - API 추가: POST /api/mixpanel/odsay-call-count 엔드포인트에서 memberId, oDsayCallCount, routeCount를 접수합니다.
- 작업
  - Mixpanel Java SDK 런타임 의존성을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->